### PR TITLE
feat(skill): add x-fixing-vulnerability npm audit skill

### DIFF
--- a/.claude/skills/x-fixing-vulnerability/SKILL.md
+++ b/.claude/skills/x-fixing-vulnerability/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: x-fixing-vulnerability
+description: detect & fix npm audit vulns (high+) at repo root; no --force; auto-rollback on lint+build failure
+argument-hint: ""
+allowed-tools: Bash(npm:*), Bash(git:*), Bash(jq:*)
+---
+
+# npm Vulnerability Fix Skill
+
+Detect and fix npm audit vulnerabilities (`--audit-level=high`) for the single root `package.json` of this project. No `--force`. No `git commit` / `git push` — the human reviews and commits.
+
+## Scope & rules
+
+- **Single root package.json.** No `frontend/`, no sub-packages, no multi-directory logic.
+- **Target level:** `--audit-level=high` (high + critical only; moderate / low are out of scope). This is a project policy, not a CI mirror — this repo has no CI.
+- **Verification = lint + build only:** `npm run lint` then `npm run build`. There is no test script in this project.
+- **Prohibited:** `npm audit fix --force` (major-version jumps cause breaking changes). Never run it.
+- **No commit:** the skill never runs `git commit` / `git push`. The human reviews the diff and commits.
+- **Runtime branch** is `fix/npm-audit-vulnerabilities` — do not confuse it with any authoring branch.
+
+## Workflow
+
+### Phase 1: Audit-first
+
+1. Run `npm audit --audit-level=high --json` and `npm audit --audit-level=high` (human-readable).
+2. Parse `metadata.vulnerabilities` from the JSON for `high` and `critical` counts.
+
+> **Exit code:** `npm audit` returns non-zero when vulnerabilities exist. That non-zero exit is the *expected* signal that vulns were found — it is NOT a command failure. Read the counts, not the exit status.
+
+3. If `high == 0` and `critical == 0` → report **clean** and **STOP**. Create no branch, make no changes.
+
+### Phase 2: Pre-flight gates (ordered)
+
+Run these in order; the first failing gate STOPs.
+
+**(A) Working tree.** `git status --porcelain`. If dirty → **STOP**, print `git status --short`, and report "Commit or stash changes before running this skill."
+
+**(B) Branch gate.** `git branch --show-current`:
+
+| Current branch | Action |
+|---------------|--------|
+| `main` / `master` | Go to gate (C) |
+| `fix/npm-audit-vulnerabilities` | Reuse it; skip gate (C) and skip Phase 4 (branch creation) |
+| Other | **STOP** — report "Switch to main or to `fix/npm-audit-vulnerabilities` first." |
+
+**(C) Existing-branch check (only when on main/master).** `git branch --list fix/npm-audit-vulnerabilities`. If the branch exists but you are not on it → **STOP** — report "Branch `fix/npm-audit-vulnerabilities` already exists; delete it (`git branch -d fix/npm-audit-vulnerabilities`) or switch to it."
+
+### Phase 3: Mandatory baseline
+
+The tree must be green *before* any fix, so a later failure is attributable to the fix.
+
+1. `npm run lint` — must pass.
+2. `npm run build` — must pass.
+
+If either fails → **STOP**. Report "Pre-existing failure — fix it first. The fix skill requires a green baseline." Create no branch.
+
+### Phase 4: Branch
+
+Skipped on the reuse path (Phase 2 gate B already on `fix/npm-audit-vulnerabilities`).
+
+From `main` / `master`: `git checkout -b fix/npm-audit-vulnerabilities`.
+
+### Phase 5: Fix
+
+1. `npm audit fix` — never `--force`.
+2. Re-run `npm audit --audit-level=high --json` to find residual vulnerabilities.
+3. For each residual vulnerability, decide overrides vs. manual:
+
+   **`overrides` (auto) — all OK conditions required:**
+   - It is a **transitive** dependency. Confirm with `jq -e '.dependencies."<pkg>" // .devDependencies."<pkg>"' package.json` — exit 1 (absent) means transitive.
+   - The advisory names a fixed version that does **not** cross a major (e.g. `1.x → 1.y` OK, `1.x → 2.x` NG).
+   - `npm view <pkg> versions --json` confirms the fixed version exists.
+
+   When all hold → add the entry to `overrides` in `package.json`, run `npm install`, record from/to.
+
+   **Manual (NG) — any of:** direct dependency, major-version jump, or fixed version unknown/missing. Do not edit; add it to the "Manual Intervention Required" list.
+
+### Phase 6: Side-effect check
+
+`git diff --stat` and `git status --porcelain`. **STOP** for manual review if anything other than `package.json` / `package-lock.json` changed, or `package-lock.json` was reformatted (e.g. tab ↔ space) rather than minimally edited.
+
+### Phase 7: Verify
+
+Run, in order — these are the only verification commands:
+
+1. `npm run lint`
+2. `npm run build`
+
+**On failure of either**, roll back and STOP:
+
+```bash
+git checkout -- package.json package-lock.json
+npm install
+```
+
+Report the failing step (lint or build), an excerpt of the error, and "tree restored, no commit made." Then **STOP**.
+
+### Phase 8: Report (no commit, no push)
+
+Render the report. Use `PASS` / `FAIL` with check (✓) / cross (✗) glyphs. Keep summaries terse; expose detail progressively (most-changed / most-severe first).
+
+```markdown
+## Vulnerability Fix Report
+
+### Severity: Before -> After
+| Severity | Before | After |
+|----------|--------|-------|
+| critical | X | X |
+| high     | X | X |
+
+### Fixes Applied
+| Package | From | To | Method | Advisory |
+|---------|------|----|--------|----------|
+| xxx | 1.2.3 | 1.2.4 | npm audit fix | GHSA-xxxx |
+| yyy | 2.0.0 | 2.1.0 | overrides | GHSA-yyyy |
+
+### Verification
+| Check | Result |
+|-------|--------|
+| npm run lint  | ✓ PASS / ✗ FAIL |
+| npm run build | ✓ PASS / ✗ FAIL |
+
+### Manual Intervention Required
+<!-- Always render this section. Print `(none)` when empty. -->
+| Package | Severity | Reason | Advisory | Suggested action |
+|---------|----------|--------|----------|------------------|
+| (none) | | | | |
+```
+
+Always append these two notes:
+
+- **Verification gap:** `npm run lint` + `npm run build` cannot catch OCR / canvas / SVG **runtime** regressions. Manually exercise the upload → OCR → editor → SVG-export flow before trusting the fix.
+- **Commit CTA:** Review the diff with `git diff`, then commit and open a PR yourself. This skill makes no commit.
+
+## Rules recap
+
+- Keep `--audit-level=high` (moderate / low out of scope).
+- Never run `npm audit fix --force`.
+- Roll back (`git checkout -- package.json package-lock.json` + `npm install`) on any lint/build failure.
+- Never `git commit` / `git push` — the human reviews and commits.
+- `overrides` only for transitive, non-major, confirmed-existing fixes; direct/major go to manual.
+- Stop on any side-effect outside `package.json` / `package-lock.json`.


### PR DESCRIPTION
## Summary
Adds the Claude Code skill `x-fixing-vulnerability` that detects and fixes npm audit vulnerabilities (`--audit-level=high`) for this project's single root `package.json`. The skill is adapted from the `lambda-function-transit` reference flow but reshaped for a single-root, no-test project, and adopts the stronger safety model from `kanji-grade` (mandatory green baseline, side-effect check, auto-rollback, no auto-commit, no `--force`).

## Changes
- Add `.claude/skills/x-fixing-vulnerability/SKILL.md` (new file, 142 lines)
- Frontmatter: `name`, `description`, `argument-hint: ""`, `allowed-tools: Bash(npm:*), Bash(git:*), Bash(jq:*)`
- 8-phase workflow: audit-first (non-zero exit is expected, not a failure) -> ordered pre-flight gates (dirty tree / branch gate / existing-branch) -> mandatory lint+build baseline -> branch (with reuse of `fix/npm-audit-vulnerabilities`) -> fix (`npm audit fix`, no `--force`; gated `overrides` for confirmed transitive non-major fixes) -> side-effect check -> verify (lint+build only, auto-rollback on failure) -> report (no commit/push, with the lint+build runtime-gap caveat)

## Verification
Commands run on the authoring branch `feat/add-fixing-vulnerability-skill`:
- `npm run lint` -> PASS (exit 0; 0 errors, 1 pre-existing unrelated `<img>` warning)
- `npm run build` -> PASS (exit 0; compiled successfully)
- No `test` script exists in this project, so tests were skipped (none defined).

x-code-reviewer: 0 Critical, 0 Warning on the skill file (3 minor optional suggestions). All five safety invariants verified.

Acceptance criteria (graded by an independent completion grader, all MET):
- [x] `test -f .claude/skills/x-fixing-vulnerability/SKILL.md` exits 0
- [x] Frontmatter `name:` equals `x-fixing-vulnerability`
- [x] `allowed-tools` line is exactly `Bash(npm:*), Bash(git:*), Bash(jq:*)`
- [x] `grep -c -- '--prefix' SKILL.md` returns 0
- [x] `grep -c 'npm test' SKILL.md` returns 0
- [x] Only verification commands referenced are `npm run lint` and `npm run build`
- [x] `--force` appears only in a prohibition
- [x] Rollback `git checkout -- package.json package-lock.json` then `npm install` is present
- [x] Audit phase documents non-zero exit with vulns is expected, not a failure
- [x] Branch logic reuses `fix/npm-audit-vulnerabilities` when on it, no STOP
- [x] Mandatory pre-fix `npm run lint` + `npm run build` baseline check is present
- [x] `npm run lint` and `npm run build` both pass on the authoring branch

Closes #3