### PR TITLE
chore(gitignore): ignore .plans directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Claude Code plan files
+.plans/


### PR DESCRIPTION
## Summary
- Add `.plans/` to `.gitignore` so Claude Code plan files are excluded from version control

## Test plan
- `git status` no longer shows the untracked `.plans/` directory